### PR TITLE
removes site specific checks from course discovery apis

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -28,8 +28,6 @@ from course_discovery.apps.course_metadata.models import (
 )
 from course_discovery.apps.publisher.models import CourseRun as PublisherCourseRun
 
-from course_discovery.apps.api.utils import get_queryset_filtered_on_organization
-
 User = get_user_model()
 
 COMMON_IGNORED_FIELDS = ('text',)
@@ -633,10 +631,8 @@ class CourseRunWithProgramsSerializer(CourseRunSerializer):
     programs = serializers.SerializerMethodField()
 
     @classmethod
-    def prefetch_queryset(cls, queryset=None, edx_org_short_name=None):
-        edx_org_filter = 'course__authoring_organizations__key'
+    def prefetch_queryset(cls, queryset=None):
         queryset = super().prefetch_queryset(queryset=queryset)
-        queryset = get_queryset_filtered_on_organization(queryset, edx_org_filter, edx_org_short_name)
 
         return queryset.prefetch_related('course__programs__excluded_course_runs')
 
@@ -756,14 +752,12 @@ class CourseWithProgramsSerializer(CourseSerializer):
     programs = serializers.SerializerMethodField()
 
     @classmethod
-    def prefetch_queryset(cls, partner, edx_org_short_name=None, queryset=None, course_runs=None):
+    def prefetch_queryset(cls, partner, queryset=None, course_runs=None):
         """
         Similar to the CourseSerializer's prefetch_queryset, but prefetches a
         filtered CourseRun queryset.
         """
-        edx_org_filter = 'authoring_organizations__key'
         queryset = queryset if queryset is not None else Course.objects.filter(partner=partner)
-        queryset = get_queryset_filtered_on_organization(queryset, edx_org_filter, edx_org_short_name)
 
         return queryset.select_related('level_type', 'video', 'partner').prefetch_related(
             'expected_learning_items',
@@ -943,11 +937,9 @@ class MinimalProgramSerializer(serializers.ModelSerializer):
     degree = DegreeSerializer(allow_null=True, required=False)
 
     @classmethod
-    def prefetch_queryset(cls, partner, queryset=None, edx_org_short_name=None):
+    def prefetch_queryset(cls, partner, queryset=None):
         # Explicitly check if the queryset is None before selecting related
-        edx_org_filter = 'authoring_organizations__key'
         queryset = queryset if queryset is not None else Program.objects.filter(partner=partner)
-        queryset = get_queryset_filtered_on_organization(queryset, edx_org_filter, edx_org_short_name)
 
         return queryset.select_related('type', 'partner').prefetch_related(
             'excluded_course_runs',
@@ -1079,7 +1071,7 @@ class ProgramSerializer(MinimalProgramSerializer):
     marketing_slug = CharField()
 
     @classmethod
-    def prefetch_queryset(cls, partner, queryset=None, edx_org_short_name=None):
+    def prefetch_queryset(cls, partner, queryset=None):
         """
         Prefetch the related objects that will be serialized with a `Program`.
 
@@ -1087,9 +1079,7 @@ class ProgramSerializer(MinimalProgramSerializer):
         chain of related fields from programs to course runs (i.e., we want control over
         the querysets that we're prefetching).
         """
-        edx_org_filter = 'authoring_organizations__key'
         queryset = queryset if queryset is not None else Program.objects.filter(partner=partner)
-        queryset = get_queryset_filtered_on_organization(queryset, edx_org_filter, edx_org_short_name)
 
         return queryset.select_related('type', 'video', 'partner').prefetch_related(
             'excluded_course_runs',
@@ -1505,7 +1495,6 @@ class CourseSearchSerializer(HaystackSerializer):
             'course_runs',
             'uuid',
             'subjects',
-            'org',
         )
 
 

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -250,18 +250,6 @@ class CourseWithProgramsSerializerTests(CourseSerializerTests):
         )
         self.assertEqual(serializer.data, self.get_expected_data(self.course, self.request))
 
-    def test_filter_courses_on_edx_org_short_name(self):
-        """
-        Verify courses filtering on edX organization works as expected..
-        """
-        edx_org_short_name = 'edx'
-        edx_org_course = CourseFactory(partner=self.partner, authoring_organizations__key=edx_org_short_name)
-        serialized_courses = self.serializer_class.prefetch_queryset(
-            partner=self.partner,
-            edx_org_short_name=edx_org_short_name
-        )
-        assert serialized_courses.values() != self.get_expected_data(edx_org_course, self.request).values()
-
 
 class MinimalCourseRunBaseTestSerializer(TestCase):
     serializer_class = MinimalCourseRunSerializer
@@ -444,17 +432,6 @@ class CourseRunWithProgramsSerializerTests(TestCase):
             serializer.data['programs'],
             NestedProgramSerializer([retired_program], many=True, context=self.serializer_context).data
         )
-
-    def test_filter_course_runs_on_edx_org_short_name(self):
-        """
-        Verify course runs filtering on edX organization works as expected.
-        """
-        edx_org_short_name = 'edx'
-        edx_org_course = CourseRunFactory(course__authoring_organizations__key=edx_org_short_name)
-        serialized_course_runs = CourseRunWithProgramsSerializer.prefetch_queryset(
-            edx_org_short_name=edx_org_short_name
-        )
-        assert serialized_course_runs.values() != self.get_expected_data(edx_org_course, self.request).values()
 
     @classmethod
     def get_expected_data(cls, course_run, request):
@@ -733,16 +710,6 @@ class MinimalProgramSerializerTests(TestCase):
         serializer = self.serializer_class(program, context={'request': request})
         expected = self.get_expected_data(program, request)
         self.assertDictEqual(serializer.data, expected)
-
-    def test_filter_programs_on_edx_org_short_name(self):
-        """
-        Verify programs filtering on edX organization works as expected.
-        """
-        edx_org_short_name = 'edx'
-        request = make_request()
-        edx_org_program = ProgramFactory(authoring_organizations__key=edx_org_short_name)
-        serializer = self.serializer_class(edx_org_program, context={'request': request})
-        assert serializer.data['title'] == self.get_expected_data(edx_org_program, request)['title']
 
 
 class ProgramSerializerTests(MinimalProgramSerializerTests):
@@ -1037,16 +1004,6 @@ class ProgramSerializerTests(MinimalProgramSerializerTests):
         }
         self.assertDictEqual(serializer.data, expected)
 
-    def test_filter_programs_on_edx_org_short_name(self):
-        """
-        Verify programs filtering on edX organization works as expected.
-        """
-        edx_org_short_name = 'edx'
-        request = make_request()
-        edx_org_program = ProgramFactory(authoring_organizations__key=edx_org_short_name)
-        serializer = self.serializer_class(edx_org_program, context={'request': request})
-        assert serializer.data['title'] == self.get_expected_data(edx_org_program, request)['title']
-
 
 class PathwaySerialzerTests(TestCase):
     def test_data(self):
@@ -1102,25 +1059,6 @@ class ContainedCourseRunsSerializerTests(TestCase):
         }
         serializer = ContainedCourseRunsSerializer(instance)
         self.assertDictEqual(serializer.data, instance)
-
-    def test_contained_course_runs_filtered_on_edx_org_short_name(self):
-        """
-        Verify course runs keys filtering on elastic search query string & edX organization.
-        """
-        edx_org_short_name = 'edx'
-        edx_org_course_run_key = 'course-v1:edX+DemoX+Demo_Course'
-        course_run_ids = [edx_org_course_run_key]
-        course_runs_with_org_filter = CourseRun.objects.filter(course__authoring_organizations__key=edx_org_short_name)
-        course_runs_keys = course_runs_with_org_filter.values_list('key', flat=True)
-        contained_course_runs = {course_run_id: course_run_id in course_runs_keys for course_run_id in course_run_ids}
-        course_runs_instances = {'course_runs': contained_course_runs}
-        contained_course_runs_serializer = ContainedCourseRunsSerializer(course_runs_instances)
-        expected_contained_courses = {
-            'course_runs': {
-                edx_org_course_run_key: False
-            }
-        }
-        assert contained_course_runs_serializer.data == expected_contained_courses
 
 
 class ContainedCoursesSerializerTests(TestCase):
@@ -1557,7 +1495,6 @@ class CourseSearchSerializerTests(TestCase, CourseSearchSerializerMixin):
             }],
             'uuid': str(course.uuid),
             'subjects': [subject.name for subject in course.subjects.all()],
-            'org': course.authoring_organizations,
         }
 
 

--- a/course_discovery/apps/api/tests/test_utils.py
+++ b/course_discovery/apps/api/tests/test_utils.py
@@ -8,9 +8,7 @@ from rest_framework.test import APIRequestFactory
 from course_discovery.apps.api.utils import (
     cast2int,
     get_query_param,
-    get_queryset_filtered_on_organization
 )
-from course_discovery.apps.course_metadata.models import Course, CourseRun
 
 LOGGER_PATH = 'course_discovery.apps.api.utils.logger.exception'
 
@@ -46,30 +44,3 @@ class TestGetQueryParam:
 
     def test_without_request(self):
         assert get_query_param(None, 'q') is None
-
-
-class TestGetQuerysetFilteredOnOrganization:
-
-    @pytest.mark.django_db
-    def test_courses_runs_filter_on_edx_shortname(self):
-        edx_org_filter = 'course__authoring_organizations__key'
-        edx_org_short_name = 'edx'
-        edx_course_run_key = 'course-v1:edX+DemoX+Demo_Course'
-        expected_course_runs_queryset = CourseRun.objects.filter(course__authoring_organizations__key=edx_org_short_name)
-
-        course_runs_queryset = CourseRun.objects.filter(key=edx_course_run_key)
-        actual_course_runs_queryset = get_queryset_filtered_on_organization(course_runs_queryset, edx_org_filter, edx_org_short_name)
-
-        assert len(actual_course_runs_queryset) == len(expected_course_runs_queryset)
-
-    @pytest.mark.django_db
-    def test_course_filter_on_edx_shortname(self):
-        edx_org_filter = 'authoring_organizations__key'
-        edx_org_short_name = 'edx'
-        edx_course_key = 'course-v1:edX+DemoX+Demo_Course'
-        expected_courses_queryset = Course.objects.filter(authoring_organizations__key=edx_org_short_name)
-
-        courses_queryset = Course.objects.filter(key=edx_course_key)
-        actual_courses_queryset = get_queryset_filtered_on_organization(courses_queryset, edx_org_filter, edx_org_short_name)
-
-        assert len(actual_courses_queryset) == len(expected_courses_queryset)

--- a/course_discovery/apps/api/utils.py
+++ b/course_discovery/apps/api/utils.py
@@ -65,18 +65,3 @@ def get_cache_key(**kwargs):
     key = '__'.join(['{}:{}'.format(item, value) for item, value in six.iteritems(kwargs)])
 
     return hashlib.md5(key.encode('utf-8')).hexdigest()
-
-
-def get_queryset_filtered_on_organization(queryset, edx_org_filter, edx_org_short_name):
-    """
-    Get queryset filtered on edx organization short name.
-
-    Arguments:
-        queryset (DRF queryset object): DRF Queryset object.
-        edx_org_filter (str): Filter to use in queryset.
-        edx_org_short_name (str): Edx organization short name.
-
-    Returns:
-        A DRF queryset object with organization filter applied.
-    """
-    return queryset if not edx_org_short_name else queryset.filter(**{edx_org_filter: edx_org_short_name})

--- a/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
@@ -21,15 +21,9 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
     def setUp(self):
         super(CourseRunViewSetTests, self).setUp()
         self.user = UserFactory(is_staff=True, is_superuser=True)
-        self.edx_org_short_name = 'edx'
         self.client.force_authenticate(self.user)
         self.course_run = CourseRunFactory(course__partner=self.partner)
         self.course_run_2 = CourseRunFactory(course__partner=self.partner)
-        # Course_run of edx organization
-        self.course_run_3 = CourseRunFactory(
-            course__partner=self.partner,
-            course__authoring_organizations__key=self.edx_org_short_name
-        )
         self.refresh_index()
         self.request = APIRequestFactory().get('/')
         self.request.user = self.user
@@ -140,24 +134,6 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
             response.data['results'],
             self.serialize_course_run(CourseRun.objects.all().order_by(Lower('key')), many=True)
         )
-
-    def test_list_edx_org_short_name_filter(self):
-        """
-        Verify course runs filtering on edX organization.
-        """
-        course_run_api_url_with_org_filter = '{course_run_api_url}?org={edx_org_short_name}'.format(
-            course_run_api_url=reverse('api:v1:course_run-list'),
-            edx_org_short_name=self.edx_org_short_name
-        )
-        expected_serialized_course_runs = self.serialize_course_run(
-            CourseRun.objects.filter(course__authoring_organizations__key=self.edx_org_short_name).order_by(Lower('key')),
-            many=True
-        )
-
-        response = self.client.get(course_run_api_url_with_org_filter)
-        assert response.status_code == 200
-        course_runs_from_response = response.data['results']
-        assert course_runs_from_response == expected_serialized_course_runs
 
     def test_list_sorted_by_course_start_date(self):
         """ Verify the endpoint returns a list of all course runs sorted by start date. """
@@ -302,37 +278,6 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
                 }
             }
         )
-
-    def test_contains_multiple_course_runs_edx_org_short_name_filter(self):
-        """
-        Verify contained course runs filtering on edX organization.
-        """
-        edx_org_course_run_key = 'course-v1:edX+DemoX+Demo_Course'
-        elastic_search_query_string_with_org_filter = urllib.parse.urlencode({
-            'query': 'id:course*',
-            'course_run_ids': '{course_run_1_key},{course_run_2_key},{course_run_3_key}'.format(
-                course_run_1_key=self.course_run_2.key,
-                course_run_2_key=self.course_run_3.key,
-                course_run_3_key=edx_org_course_run_key
-            ),
-            'org': self.edx_org_short_name
-        })
-        course_run_api_url_with_org_filter = '{course_run_api_url}?{elastic_search_query_string_with_org_filter}'.format(
-            course_run_api_url=reverse('api:v1:course_run-contains'),
-            elastic_search_query_string_with_org_filter=elastic_search_query_string_with_org_filter
-        )
-        expected_serialized_contained_course_runs = {
-            'course_runs': {
-                self.course_run_2.key: False,
-                self.course_run_3.key: False,
-                edx_org_course_run_key: False
-            }
-        }
-
-        response = self.client.get(course_run_api_url_with_org_filter)
-        assert response.status_code == 200
-        course_runs_from_response = response.data
-        assert course_runs_from_response == expected_serialized_contained_course_runs
 
     @ddt.data(
         {'params': {'course_run_ids': 'a/b/c'}},

--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -24,7 +24,6 @@ class CourseViewSetTests(SerializationMixin, APITestCase):
         self.request.user = self.user
         self.client.login(username=self.user.username, password=USER_PASSWORD)
         self.course = CourseFactory(partner=self.partner)
-        self.edx_org_short_name = 'edx'
 
     def test_get(self):
         """ Verify the endpoint returns the details for a single course. """
@@ -204,24 +203,6 @@ class CourseViewSetTests(SerializationMixin, APITestCase):
                 response.data['results'],
                 self.serialize_course(Course.objects.all().order_by(Lower('key')), many=True)
             )
-
-    def test_edx_org_short_name_filter(self):
-        """
-        Verify courses filtering on edX organization.
-        """
-        course_api_url_with_org_filter = '{courses_api_url}?org={edx_org_short_name}'.format(
-            courses_api_url=reverse('api:v1:course-list'),
-            edx_org_short_name=self.edx_org_short_name
-        )
-        expected_serialized_courses = self.serialize_course(
-            Course.objects.filter(authoring_organizations__key=self.edx_org_short_name).order_by(Lower('key')),
-            many=True
-        )
-
-        response = self.client.get(course_api_url_with_org_filter)
-        assert response.status_code == 200
-        courses_from_response = response.data['results']
-        assert courses_from_response == expected_serialized_courses
 
     def test_list_query(self):
         """ Verify the endpoint returns a filtered list of courses """

--- a/course_discovery/apps/api/v1/tests/test_views/test_programs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_programs.py
@@ -165,25 +165,6 @@ class TestProgramViewSet(SerializationMixin):
 
         self.assert_list_results(self.list_path, expected, 28)
 
-    def test_edx_org_short_name_filter(self):
-        """
-        Verify programs filtering on edX organization.
-        """
-        edx_org_short_name = 'edx'
-        programs_api_url_with_org_filter = '{programs_api_url}?org={edx_org_short_name}'.format(
-            programs_api_url=self.list_path,
-            edx_org_short_name=edx_org_short_name
-        )
-        expected_serialized_programs = self.serialize_program(
-            Program.objects.filter(authoring_organizations__key=edx_org_short_name),
-            many=True
-        )
-
-        response = self.client.get(programs_api_url_with_org_filter)
-        assert response.status_code == 200
-        programs_from_response = response.data['results']
-        assert programs_from_response == expected_serialized_programs
-
     def test_uuids_only(self):
         """
         Verify that the list view returns a simply list of UUIDs when the

--- a/course_discovery/apps/api/v1/views/course_runs.py
+++ b/course_discovery/apps/api/v1/views/course_runs.py
@@ -43,7 +43,6 @@ class CourseRunViewSet(viewsets.ModelViewSet):
         """
         q = self.request.query_params.get('q')
         partner = self.request.site.partner
-        edx_org_short_name = self.request.query_params.get('org')
 
         if q:
             qs = SearchQuerySetWrapper(CourseRun.search(q).filter(partner=partner.short_code))
@@ -52,7 +51,7 @@ class CourseRunViewSet(viewsets.ModelViewSet):
             return qs
         else:
             queryset = super(CourseRunViewSet, self).get_queryset().filter(course__partner=partner)
-            return self.get_serializer_class().prefetch_queryset(queryset=queryset, edx_org_short_name=edx_org_short_name)
+            return self.get_serializer_class().prefetch_queryset(queryset=queryset)
 
     def get_serializer_context(self, *args, **kwargs):
         context = super().get_serializer_context(*args, **kwargs)
@@ -125,12 +124,6 @@ class CourseRunViewSet(viewsets.ModelViewSet):
               type: integer
               paramType: query
               multiple: false
-            - name: org
-              description: Filter results on edx organization's short name.
-              required: false
-              type: string
-              paramType: query
-              multiple: false
         """
         return super(CourseRunViewSet, self).list(request, *args, **kwargs)
 
@@ -170,23 +163,14 @@ class CourseRunViewSet(viewsets.ModelViewSet):
               type: string
               paramType: query
               multiple: false
-            - name: org
-              description: Filter results on edx organization's short name.
-              required: false
-              type: string
-              paramType: query
-              multiple: false
         """
         query = request.GET.get('query')
         course_run_ids = request.GET.get('course_run_ids')
         partner = self.request.site.partner
-        edx_org_short_name = request.GET.get('org')
 
         if query and course_run_ids:
             course_run_ids = course_run_ids.split(',')
-            course_runs = CourseRun.search(query).filter(partner=partner.short_code).filter(key__in=course_run_ids)
-            # update "course_runs" with edx organization filter
-            course_runs = course_runs.filter(course__authoring_organizations__key=edx_org_short_name).values_list('key', flat=True)
+            course_runs = CourseRun.search(query).filter(partner=partner.short_code).filter(key__in=course_run_ids).values_list('key', flat=True)
             contains = {course_run_id: course_run_id in course_runs for course_run_id in course_run_ids}
 
             instance = {'course_runs': contains}

--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -52,7 +52,6 @@ class CourseViewSet(viewsets.ReadOnlyModelViewSet):
     def get_queryset(self):
         partner = self.request.site.partner
         q = self.request.query_params.get('q')
-        edx_org_short_name = self.request.query_params.get('org')
 
         if q:
             queryset = Course.search(q)
@@ -74,7 +73,6 @@ class CourseViewSet(viewsets.ReadOnlyModelViewSet):
 
             queryset = self.get_serializer_class().prefetch_queryset(
                 queryset=self.queryset,
-                edx_org_short_name=edx_org_short_name,
                 course_runs=course_runs,
                 partner=partner
             )
@@ -140,12 +138,6 @@ class CourseViewSet(viewsets.ReadOnlyModelViewSet):
               mulitple: false
             - name: q
               description: Elasticsearch querystring query. This filter takes precedence over other filters.
-              required: false
-              type: string
-              paramType: query
-              multiple: false
-            - name: org
-              description: Filter results on edx organization's short name.
               required: false
               type: string
               paramType: query

--- a/course_discovery/apps/api/v1/views/programs.py
+++ b/course_discovery/apps/api/v1/views/programs.py
@@ -33,13 +33,12 @@ class ProgramViewSet(CacheResponseMixin, viewsets.ModelViewSet):
         # which happens when the queryset is stored in a class property.
         partner = self.request.site.partner
         q = self.request.query_params.get('q')
-        edx_org_short_name = self.request.query_params.get('org')
         queryset = None
 
         if q:
             queryset = Program.search(q)
 
-        return self.get_serializer_class().prefetch_queryset(queryset=queryset, partner=partner, edx_org_short_name=edx_org_short_name)
+        return self.get_serializer_class().prefetch_queryset(queryset=queryset, partner=partner)
 
     def get_serializer_context(self, *args, **kwargs):
         context = super().get_serializer_context(*args, **kwargs)
@@ -152,12 +151,6 @@ class ProgramViewSet(CacheResponseMixin, viewsets.ModelViewSet):
               multiple: false
             - name: q
               description: Elasticsearch querystring query. This filter takes precedence over other filters
-              required: false
-              type: string
-              paramType: query
-              multiple: false
-            - name: org
-              description: Filter results on edx organization's short name.
               required: false
               type: string
               paramType: query


### PR DESCRIPTION
## Ticket Link:
[https://edlyio.atlassian.net/browse/LUMS-14](https://edlyio.atlassian.net/browse/LUMS-14)

## Ticket Description:
remove site-specific checks from course discovery APIs of courses, course runs, programs added by edly cloud
* [https://github.com/edly-io/course-discovery/pull/4](https://github.com/edly-io/course-discovery/pull/4)
* [https://github.com/edly-io/course-discovery/pull/5](https://github.com/edly-io/course-discovery/pull/5)